### PR TITLE
Functionality for partial claims when cancelling and updating

### DIFF
--- a/test/TestTWAMM.t.sol
+++ b/test/TestTWAMM.t.sol
@@ -219,7 +219,7 @@ contract TWAMMHookTest is Test, GasSnapshot, Deployers {
         twammHook.initiateBuyback(poolKey, buybackAmount, duration, interval, true);
 
         vm.prank(address(0xdead));
-        vm.expectRevert(TWAMMHook.OnlyInitiatorCanClaim.selector);
+        vm.expectRevert();
         twammHook.claimBoughtTokens(poolKey);
     }
 


### PR DESCRIPTION
- When cancelling or updating the order, there might be some intervals passed and buyback hasn't happened
- Added logic to calculate those intervals and execute buyback before proceeding with update or cancellation
- This ensures no intervals are skipped during order updates or cancellations
- Implemented partial claims functionality
- Other minor changes and improvements